### PR TITLE
[Fix] : RequestLine이 null로 오는 경우 에러 로그 출력 후 소켓 통신 종료

### DIFF
--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -33,6 +33,10 @@ public class RequestHandler extends Thread {
             BufferedReader br = new BufferedReader(new InputStreamReader(in));
             HttpRequest httpRequest = new HttpRequest(br);
             String url = httpRequest.getPath();
+            if (url == null) {
+                log.error("400 Bad Request");
+                return;
+            }
             switch (httpRequest.getHttpMethod()) {
                 case GET:
                     httpGetRequestHandler(out, br, url);


### PR DESCRIPTION
Fixed #10 Issue Resolved